### PR TITLE
Add global header block

### DIFF
--- a/blocks/global-header/README.md
+++ b/blocks/global-header/README.md
@@ -1,0 +1,22 @@
+# Global Header
+
+## Register as a block (for Full Site Editing themes)
+
+Add as a composer dependency, install, then
+
+```php
+add_action( 'muplugins_loaded', function() {
+	require_once REPO_TOOLS_DIR . '/block.php';
+} );
+```
+
+
+## Include directly in PHP (for classic themes)
+
+Add as a composer dependency, install, then
+
+require_once 'vendor/wporg-repo-tools/blocks/global-header/header.php';
+
+
+## Embed as an iframe (for Trac, Codex, etc)
+

--- a/blocks/global-header/block.php
+++ b/blocks/global-header/block.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace WordPress_org\Repo_Tools\Global_Header;
+
+defined( 'WPINC' ) || die();
+
+add_action( 'init', __NAMESPACE__ . '\register_assets', 9 );
+
+function register_assets() {
+	register_block_type(
+		'wordpress-org/global-header',
+		array( 'render_callback' => __NAMESPACE__ . '\render_global_header' )
+	);
+}
+
+function render_global_header( $attributes ) {
+	ob_start();
+	require_once __DIR__ . '/header.php';
+	return ob_get_clean();
+}
+

--- a/blocks/global-header/header.php
+++ b/blocks/global-header/header.php
@@ -1,0 +1,2 @@
+<?php
+echo 'this is the global header :)';


### PR DESCRIPTION
this is a rough sketch of how `repo-tools` could contain the global header, with all themes could include in various ways

interconnected with https://github.com/WordPress/wporg-news-2021/issues/20

see #6 

if this sounds good, i'll add the rest