### PR TITLE
Add a basic child theme template

### DIFF
--- a/bin/create
+++ b/bin/create
@@ -1,0 +1,116 @@
+#!/usr/bin/env php
+<?php
+namespace WordPressdotorg\Bin\Create;
+
+if ( php_sapi_name() !== 'cli' ) {
+	exit;
+}
+
+require dirname( __DIR__ ) . '/vendor/autoload.php';
+
+use Minicli\App;
+use Minicli\Input;
+use Minicli\Command\CommandCall;
+
+\Mustache_Autoloader::register();
+
+$app = new App();
+$app->setSignature( './bin/create child-theme' );
+
+/**
+ * Run the prompts from the project's configuration.
+ *
+ * @param array $prompts A set of properties used to request user input.
+ * @param array $params  The parameters provided to the script on the command line.
+ * @return array The merged list of values - from user input, command line, or defaults.
+ */
+function run_prompts( $prompts, $params ) {
+	$settings = array_fill_keys( array_keys( $prompts ), '' );
+
+	foreach ( $prompts as $key => $prompt ) {
+		$validation = $prompt['validate'] ?: function( $value ) { return $value; };
+
+		// If the value was provided in CLI args, skip the prompt.
+		if ( isset( $params[ '--' . $key ] ) ) {
+			$settings[ $key ] = call_user_func( $validation, $params[ '--' . $key ] );
+		} else {
+			if ( $prompt['default'] ) {
+				$request = new Input( sprintf( '%1$s [default: %2$s]: ', $prompt['message'], $prompt['default'] ) );
+			} else {
+				$request = new Input( sprintf( '%s: ', $prompt['message'] ) );
+			}
+
+			$response = $request->read();
+			$settings[ $key ] = call_user_func( $validation, $response );
+		}
+
+		// If we still have no value, inherit the default.
+		if ( empty( $settings[ $key ] ) ) {
+			$settings[ $key ] = $prompt['default'];
+		}
+	}
+
+	return $settings;
+}
+
+$app->registerCommand(
+	'child-theme',
+	function( CommandCall $input ) use ( $app ) {
+		$app->getPrinter()->display( "Let's create a child theme project!" );
+		$app->getPrinter()->out( 'Hit enter to accept the default values.', 'info' );
+		$app->getPrinter()->newline();
+		$app->getPrinter()->newline();
+
+		$template_path = dirname( __DIR__ ) . '/templates/child-theme';
+		$raw_files = scandir( $template_path );
+		$files = array_filter(
+			$raw_files,
+			function( $file ) {
+				return preg_match( '/\.mustache$/', $file );
+			}
+		);
+
+		if ( empty( $files ) ) {
+			$app->getPrinter()->error( "Can't find any project templates in $template_path" );
+			return;
+		}
+
+		$prompts = require_once( $template_path . '/create-project.config.php' );
+		if ( empty( $prompts['slug'] ) || empty( $prompts['slug']['default'] ) ) {
+			$app->getPrinter()->error( 'Project is not configured correctly. Slug is a required prompt, and must have a default.' );
+			return;
+		}
+
+		$settings = run_prompts( $prompts, $input->params );
+
+		// Generate any built values (like slugSnakeCase).
+		$settings['slugSnakeCase'] = str_replace( ' ', '', ucwords( str_replace( '-', ' ', $settings['slug'] ) ) );
+
+		$app->getPrinter()->display( 'Generating theme…' );
+		$m = new \Mustache_Engine;
+
+		$project_path = getcwd() . '/' . $settings['slug'];
+		$result = mkdir( $project_path );
+		if ( ! $result ) {
+			$app->getPrinter()->error( "Couldn't create directory $project_path" );
+			return;
+		}
+
+		foreach ( $files as $file ) {
+			$file_content = file_get_contents( $template_path . '/' . $file );
+			$new_content = $m->render( $file_content, $settings );
+			$new_file = preg_replace( '/\.mustache$/', '', $file );
+			$result = file_put_contents( $project_path . '/' . $new_file, $new_content );
+
+			// This is an error whether this is false or "zero bytes".
+			if ( ! $result ) {
+				$app->getPrinter()->error( "Nothing written to $project_path/$new_file" );
+				return;
+			}
+		}
+
+		$app->getPrinter()->success( "Tada! Theme created in $project_path" );
+	}
+);
+
+$app->runCommand( $argv );

--- a/composer.json
+++ b/composer.json
@@ -8,5 +8,9 @@
 	},
 	"bin": [
 		"bin/update-configs"
-	]
+	],
+	"require": {
+		"minicli/minicli": "^2.2",
+		"mustache/mustache": "^2.14"
+	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,123 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "298e74f41bd5a5da7dd3b19a249f6b95",
+    "packages": [
+        {
+            "name": "minicli/minicli",
+            "version": "2.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/minicli/minicli.git",
+                "reference": "7a136614949b47d716769a037a1107e414bc4f38"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/minicli/minicli/zipball/7a136614949b47d716769a037a1107e414bc4f38",
+                "reference": "7a136614949b47d716769a037a1107e414bc4f38",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.16",
+                "pestphp/pest": "^1.0",
+                "phpunit/phpunit": "^9.0"
+            },
+            "suggest": {
+                "ext-readline": "For obtaining user input"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Assets\\": "tests/Assets",
+                    "Minicli\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Experimental micro CLI framework for PHP",
+            "homepage": "https://github.com/minicli/minicli",
+            "keywords": [
+                "cli",
+                "command-line"
+            ],
+            "support": {
+                "issues": "https://github.com/minicli/minicli/issues",
+                "source": "https://github.com/minicli/minicli/tree/2.2.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/erikaheidi",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-10-30T07:30:03+00:00"
+        },
+        {
+            "name": "mustache/mustache",
+            "version": "v2.14.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bobthecow/mustache.php.git",
+                "reference": "579ffa5c96e1d292c060b3dd62811ff01ad8c24e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bobthecow/mustache.php/zipball/579ffa5c96e1d292c060b3dd62811ff01ad8c24e",
+                "reference": "579ffa5c96e1d292c060b3dd62811ff01ad8c24e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2.4"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "~1.11",
+                "phpunit/phpunit": "~3.7|~4.0|~5.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Mustache": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Justin Hileman",
+                    "email": "justin@justinhileman.info",
+                    "homepage": "http://justinhileman.com"
+                }
+            ],
+            "description": "A Mustache implementation in PHP.",
+            "homepage": "https://github.com/bobthecow/mustache.php",
+            "keywords": [
+                "mustache",
+                "templating"
+            ],
+            "support": {
+                "issues": "https://github.com/bobthecow/mustache.php/issues",
+                "source": "https://github.com/bobthecow/mustache.php/tree/v2.14.1"
+            },
+            "time": "2022-01-21T06:08:36+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.3.0"
+}

--- a/templates/child-theme/create-project.config.php
+++ b/templates/child-theme/create-project.config.php
@@ -1,0 +1,44 @@
+<?php
+namespace WordPressdotorg\Bin\Create\ChildTheme;
+
+/**
+ * Convert a string value into a slug (kebab-case).
+ * Forked and trimmed down from sanitize_title_with_dashes.
+ *
+ * @param string $value
+ * @return string
+ */
+function sanitize_slug( $value ) {
+	$value = strip_tags( $value );
+	$value = strtolower( $value );
+	$value = str_replace( '.', '-', $value );
+	$value = preg_replace( '/[^%a-z0-9 _-]/', '', $value );
+	$value = preg_replace( '/\s+/', '-', $value );
+	$value = preg_replace( '|-+|', '-', $value );
+	$value = trim( $value, '-' );
+
+	return $value;
+}
+
+return array(
+	'title' => array(
+		'message' => 'The display title for the theme',
+		'default' => 'Child Theme',
+		'validate' => false,
+	),
+	'slug' => array(
+		'message' => 'The theme slug used for identification (also the output folder name)',
+		'default' => 'wporg-child-theme',
+		'validate' => __NAMESPACE__ . '\sanitize_slug',
+	),
+	'description' => array(
+		'message' => 'The short description for the theme',
+		'default' => '',
+		'validate' => false,
+	),
+	'textdomain' => array(
+		'message' => 'The textdomain used for this theme',
+		'default' => 'wporg',
+		'validate' => __NAMESPACE__ . '\sanitize_slug',
+	),
+);

--- a/templates/child-theme/functions.php.mustache
+++ b/templates/child-theme/functions.php.mustache
@@ -1,0 +1,23 @@
+<?php
+
+namespace WordPressdotorg\Theme\{{slugSnakeCase}};
+
+/**
+ * Actions and filters.
+ */
+add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
+
+/**
+ * Enqueue scripts and styles.
+ */
+function enqueue_assets() {
+	// The parent style is registered as `wporg-parent-2021-style`, and will be loaded unless
+	// explicitly unregistered. We can load any child-theme overrides by declaring the parent
+	// stylesheet as a dependency.
+	wp_enqueue_style(
+		'{{slug}}-style',
+		get_stylesheet_uri(),
+		array( 'wporg-parent-2021-style', 'wporg-global-fonts' ),
+		filemtime( __DIR__ . '/style.css' )
+	);
+}

--- a/templates/child-theme/style.css.mustache
+++ b/templates/child-theme/style.css.mustache
@@ -1,0 +1,16 @@
+/*
+ * Theme Name: {{title}}
+ * Theme URI: https://github.com/WordPress/{{slug}}
+ * Author: WordPress.org Meta Team
+ * Author URI: https://wordpress.org/
+ * Description: {{description}}
+ * Version: 1.0.0
+ * License: GNU General Public License v2 or later
+ * Text Domain: {{textdomain}}
+ * Template: wporg-parent-2021
+ */
+
+/*
+ * Note: only add styles here in cases where you can't achieve the style with
+ * templates or theme.json settings.
+ */

--- a/templates/child-theme/theme.json.mustache
+++ b/templates/child-theme/theme.json.mustache
@@ -1,0 +1,5 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 2,
+	"settings": {}
+}


### PR DESCRIPTION
This is a basic child theme template, which will use the `wporg-parent-2021` theme as its parent. It also includes a script to generate the project, using the same mustache template engine as `create-block`, so our templates are the same between #21 & here.

The `create` script I've written here is PHP - I did that rather than creating a new package.json so I could use JS. It's very simple, inspired from `create-block`. I had thought maybe we could switch out different templates depending on the argument -- so this has `create child-theme`, but we could also do `create env` to create a full env with `.wp-env.json`, etc.

```
$ ./bin/create child-theme

Let's create a child theme project!
Hit enter to accept the default values.

The display title for the theme [default: Child Theme]: 
The theme slug used for identification (also the output folder name) [default: wporg-child-theme]: 
The short description for the theme: 
The textdomain used for this theme [default: wporg]: 

Generating theme…

Tada! Theme created in /full/path/to/wporg-child-theme
```

This wouldn't generate blocks — the block template in #21 can be used with `@wordpress/create-block` to create mu-plugins blocks, and any blocks we want to create as standalone plugins can just be vanilla `@wordpress/create-block` (or we can make another template).