### PR TITLE
Update "Block Name" to "Plugin Name" 

### DIFF
--- a/templates/mu-block/plugin/$slug.php.mustache
+++ b/templates/mu-block/plugin/$slug.php.mustache
@@ -1,6 +1,6 @@
 <?php
 /**
- * Block Name: {{title}}
+ * Plugin Name: {{title}}
 {{#description}}
  * Description: {{description}}
 {{/description}}


### PR DESCRIPTION
When I try to include a newly made block directly into an environment, it doesn't work because it's looking for "Plugin Name". 

I'm not certain this happens in all environments but it's definitely happening when I include it in the `plugin` section in `.wp-env.json`. 

Is there any reason why we can't change it to `Plugin Name:`?

Here's an example of what I do:

```
{
	"plugins": [
		...
		"../wporg-mu-plugins/mu-plugins/blocks/new-block-name"
	],
}
```