### PR TITLE
Tools: Add composite actions for use in project workflows

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -1,0 +1,17 @@
+name: "Lint"
+description: "Run all linters"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Lint CSS
+      shell: bash
+      run: yarn workspaces run lint:css
+
+    - name: Lint JS
+      shell: bash
+      run: yarn workspaces run lint:js
+
+    - name: Lint PHP
+      shell: bash
+      run: yarn lint:php

--- a/.github/actions/readme.md
+++ b/.github/actions/readme.md
@@ -1,0 +1,50 @@
+# Composite Actions
+
+These are shared actions, meant to be used in projects' github workflows. Read more about [composite actions on the github docs](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action).
+
+- `actions/setup` This installs dependencies and sets up the project configs.
+- `actions/lint` This runs the linters for CSS, JS, and PHP
+- `actions/test-php` This runs the php unit tests
+
+They are set up as separate actions to mix and match in projects — in case any given project needs more setup steps before tests can be run, for example.
+
+The scripts assume a few things about a project:
+
+1. The project uses composer, with `wporg-repo-tools`, so that `composer exec update-configs` will work.
+2. The project uses yarn and at least one yarn workspace for the theme.
+3. Optionally, there is an `.nvmrc`.
+
+The commands in the actions assume a few standard scripts are available. 
+
+The parent project needs:
+
+- `lint:php` for lint action
+- `wp-env` for test-php action
+- `test:php` for test-php action
+
+All workspace projects need:
+
+- `build` for setup action
+- `lint:css` for lint action
+- `lint:js` for lint action
+
+## Usage
+
+These are used just like published actions, except you need to use the path to the containing folder since there are multiple actions in this repo.
+
+For example, to run the PHP Unit Tests action, add this to your workflow.
+
+```yml
+- name: Test
+  uses: WordPress/wporg-repo-tools/.github/actions/test-php
+```
+
+The setup action accepts two inputs. The `token` is required for composer to install the dependencies (the secrets are not passed through otherwise). The `textdomain` is only necessary if it's not "wporg".
+
+```yml
+- name: Setup
+  uses: WordPress/wporg-repo-tools/.github/actions/setup
+  with:
+    token: ${{ secrets.GITHUB_TOKEN }}
+    textdomain: wporg-custom
+```

--- a/.github/actions/readme.md
+++ b/.github/actions/readme.md
@@ -18,9 +18,10 @@ The commands in the actions assume a few standard scripts are available.
 
 The parent project needs:
 
-- `lint:php` for lint action
-- `wp-env` for test-php action
-- `test:php` for test-php action
+- `setup:tools` for setup action: set up the configs for dev tools.
+- `lint:php` for lint action: run phpcs across the appropriate files
+- `wp-env` for test-php action: map to a wp-env instance
+- `test:php` for test-php action: run phpunit tests
 
 All workspace projects need:
 
@@ -39,12 +40,11 @@ For example, to run the PHP Unit Tests action, add this to your workflow.
   uses: WordPress/wporg-repo-tools/.github/actions/test-php
 ```
 
-The setup action accepts two inputs. The `token` is required for composer to install the dependencies (the secrets are not passed through otherwise). The `textdomain` is only necessary if it's not "wporg".
+The setup action accepts one input. The `token` is required for composer to install the dependencies (the secrets are not passed through otherwise).
 
 ```yml
 - name: Setup
   uses: WordPress/wporg-repo-tools/.github/actions/setup
   with:
     token: ${{ secrets.GITHUB_TOKEN }}
-    textdomain: wporg-custom
 ```

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -2,11 +2,6 @@ name: "Setup"
 description: "Set up the environment"
 
 inputs:
-  textdomain:
-    description: "The textdomain used on this project."
-    default: "wporg"
-    required: false
-    type: string
   token:
     description: "A GitHub token."
     required: true
@@ -37,7 +32,7 @@ runs:
     - name: Setup configs
       shell: bash
       run: |
-        TEXTDOMAIN=${{ inputs.textdomain }} composer exec update-configs
+        yarn setup:tools
 
     - name: Build all included projects.
       shell: bash

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,44 @@
+name: "Setup"
+description: "Set up the environment"
+
+inputs:
+  textdomain:
+    description: "The textdomain used on this project."
+    default: "wporg"
+    required: false
+    type: string
+  token:
+    description: "A GitHub token."
+    required: true
+    type: string
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install NodeJS
+      uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8 # v3.7.0
+      with:
+        node-version-file: ".nvmrc"
+        cache: "yarn"
+
+    - name: Setup PHP with PECL extension
+      uses: shivammathur/setup-php@4bd44f22a98a19e0950cbad5f31095157cc9621b # v2.25.4 
+      with:
+        php-version: "7.4"
+      env:
+        COMPOSER_TOKEN: ${{ inputs.token }}
+
+    - name: Install all dependencies
+      shell: bash
+      run: |
+        composer install || composer update wporg/*
+        yarn
+
+    - name: Setup configs
+      shell: bash
+      run: |
+        TEXTDOMAIN=${{ inputs.textdomain }} composer exec update-configs
+
+    - name: Build all included projects.
+      shell: bash
+      run: yarn workspaces run build

--- a/.github/actions/test-php/action.yml
+++ b/.github/actions/test-php/action.yml
@@ -1,0 +1,13 @@
+name: "PHP Unit Tests"
+description: "Run the php unit tests"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install WordPress
+      shell: bash
+      run: yarn wp-env start
+
+    - name: Running PHP unit tests
+      shell: bash
+      run: yarn test:php


### PR DESCRIPTION
Fixes #26. This adds three composite actions that can be used sequentially in a project's workflow file.

- `actions/setup` This installs dependencies and sets up the project configs.
- `actions/lint` This runs the linters for CSS, JS, and PHP
- `actions/test-php` This runs the php unit tests

Each project can choose to use any of these, add steps between them, etc. We can also add more actions to this repo if we think of other things that are common across projects.

See https://github.com/WordPress/wporg-main-2022/pull/275 for an example in use.

More details in [the actions readme](https://github.com/WordPress/wporg-repo-tools/tree/try/reusable-workflows/.github/actions), including some expected npm scripts (see #27).

This can really only be tested by using the actions in other repos, so I think that's optional. You can see it working [on wporg-main-2022](https://github.com/WordPress/wporg-main-2022/pull/275).