### PR TITLE
Composite actions: Add an i18n action to fetch content strings

### DIFF
--- a/.github/actions/i18n/action.yml
+++ b/.github/actions/i18n/action.yml
@@ -31,3 +31,8 @@ runs:
     - name: Run translation script
       shell: bash
       run: php ${{ github.action_path }}/bin/i18n.php ${{ inputs.args }}
+
+    - name: Reset the composer files
+      shell: bash
+      run: |
+        git checkout composer.json composer.lock

--- a/.github/actions/i18n/action.yml
+++ b/.github/actions/i18n/action.yml
@@ -1,0 +1,33 @@
+name: "i18n"
+description: "Generate translation strings from content"
+
+inputs:
+  token:
+    description: "A GitHub token."
+    required: true
+    type: string
+
+  args:
+    description: "CLI args passed through to i18n script."
+    required: false
+    type: string
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup PHP with PECL extension
+      uses: shivammathur/setup-php@4bd44f22a98a19e0950cbad5f31095157cc9621b # v2.25.4 
+      with:
+        php-version: "7.4"
+      env:
+        COMPOSER_TOKEN: ${{ inputs.token }}
+
+    - name: Install composer dependencies
+      shell: bash
+      run: |
+        composer install || composer update wporg/*
+        composer require rmccue/requests:1.8.1
+
+    - name: Run translation script
+      shell: bash
+      run: php ${{ github.action_path }}/bin/i18n.php ${{ inputs.args }}

--- a/.github/actions/i18n/bin/i18n.php
+++ b/.github/actions/i18n/bin/i18n.php
@@ -393,6 +393,7 @@ class Generate_Translation_Strings {
 		$file_name = 'translation-strings.php';
 		$file_header = <<<HEADER
 <?php
+// phpcs:disable
 /**
  * Generated file for translation strings.
  *

--- a/.github/actions/i18n/bin/i18n.php
+++ b/.github/actions/i18n/bin/i18n.php
@@ -377,7 +377,7 @@ class Generate_Translation_Strings {
 
 			foreach ( $this->get_posts( $post_type ) as $page ) {
 				$title = addcslashes( $page['title']['rendered'], "'" );
-				$file_content .= "_x( '{$title}', 'Post title', '{$this->textdomain}' );\n";
+				$file_content .= "_x( '{$title}', '{$post_type['slug']} title', '{$this->textdomain}' );\n";
 
 				if ( 'cli' === php_sapi_name() ) {
 					echo "$title\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/.github/actions/i18n/bin/i18n.php
+++ b/.github/actions/i18n/bin/i18n.php
@@ -397,7 +397,7 @@ class Generate_Translation_Strings {
 /**
  * Generated file for translation strings.
  *
- * Used to import additional strings into the pattern-directory translation project.
+ * Used to import additional strings into the GlotPress translation project.
  *
  * ⚠️ This is a generated file. Do not edit manually. See bin/i18n.php.
  * ⚠️ Do not require or include this file anywhere.

--- a/.github/actions/i18n/bin/i18n.php
+++ b/.github/actions/i18n/bin/i18n.php
@@ -1,0 +1,399 @@
+#!/usr/bin/php
+<?php
+
+namespace WordPressdotorg\Repo_Tools\Bin\I18N;
+
+use Requests;
+
+function get_workspace_path() {
+	$workspace_path = getenv( 'GITHUB_WORKSPACE' );
+	if ( ! $workspace_path ) {
+		$workspace_path = __DIR__ . '/../../../..';
+	}
+	return $workspace_path;
+}
+
+require_once get_workspace_path() . '/vendor/autoload.php';
+
+class Generate_Translation_Strings {
+
+	/**
+	 * The URL to use for REST API queries.
+	 *
+	 * @var string $endpoint_base
+	 */
+	public $endpoint_base = 'https://wordpress.org/wp-json/wp/v2/';
+
+	/**
+	 * An allowed-list of taxonomies to fetch.
+	 *
+	 * @var string[] $valid_taxonomies
+	 */
+	public $valid_taxonomies = array( 'post_tag', 'category' );
+
+	/**
+	 * An allowed-list of post types to fetch.
+	 *
+	 * @var string[] $valid_post_types
+	 */
+	public $valid_post_types = array( 'post', 'page' );
+
+	/**
+	 * Initialze the class, set up the properties based on CLI args.
+	 */
+	public function __construct() {
+		$args = getopt( '', [ 'url::', 'taxonomies::', 'no_taxonomies', 'post_types::', 'no_post_types' ] );
+
+		if ( ! empty( $args['url'] ) && filter_var( $args['url'], FILTER_VALIDATE_URL ) ) {
+			$this->endpoint_base = $args['url'];
+		}
+
+		if ( ! empty( $args['taxonomies'] ) ) {
+			$this->valid_taxonomies = explode( ',', $args['taxonomies'] );
+		}
+
+		if ( isset( $args['no_taxonomies'] ) ) {
+			$this->valid_taxonomies = array();
+		}
+
+		if ( ! empty( $args['post_types'] ) ) {
+			$this->valid_post_types = explode( ',', $args['post_types'] );
+		}
+
+		if ( isset( $args['no_post_types'] ) ) {
+			$this->valid_post_types = array();
+		}
+	}
+
+	/**
+	 * Get data about taxonomies from a REST API endpoint.
+	 *
+	 * @return array
+	 */
+	public function get_taxonomies() {
+		$endpoint = $this->endpoint_base . 'taxonomies';
+
+		$response = Requests::get( $endpoint );
+
+		if ( 200 !== $response->status_code ) {
+			die( 'Could not retrieve taxonomy data.' );
+		}
+
+		$taxonomies = json_decode( $response->body, true );
+
+		if ( ! is_array( $taxonomies ) ) {
+			die( 'Taxonomies request returned unexpected data.' );
+		}
+
+		$taxonomies = array_filter(
+			$taxonomies,
+			function( $tax ) {
+				return in_array( $tax['slug'], $this->valid_taxonomies, true );
+			}
+		);
+
+		return $taxonomies;
+	}
+
+	/**
+	 * Get data about a taxonomy's terms from a REST API endpoint.
+	 *
+	 * @param array $taxonomy
+	 *
+	 * @return array
+	 */
+	public function get_taxonomy_terms( $taxonomy ) {
+		$endpoint    = $this->endpoint_base . $taxonomy['rest_base'] . '?per_page=100';
+		$terms       = array();
+		$page        = 1;
+		$total_pages = 1;
+
+		$response = Requests::get( $endpoint );
+
+		if ( isset( $response->headers['x-wp-totalpages'] ) ) {
+			$total_pages = intval( $response->headers['x-wp-totalpages'] );
+		}
+
+		while ( $page <= $total_pages ) {
+			if ( 'cli' === php_sapi_name() ) {
+				echo sprintf(
+					"Page %d... \n",
+					$page // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				);
+			}
+
+			if ( 200 !== $response->status_code ) {
+				die(
+					sprintf(
+						'Could not retrieve terms for %s.',
+						$taxonomy['slug'] // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					)
+				);
+			}
+
+			$more_terms = json_decode( $response->body, true );
+
+			if ( ! is_array( $more_terms ) ) {
+				die(
+					sprintf(
+						'Terms request for %s returned unexpected data.',
+						$taxonomy['slug'] // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					)
+				);
+			}
+
+			$terms = array_merge( $terms, $more_terms );
+
+			$links = array();
+			if ( isset( $response->headers['link'] ) ) {
+				$links = $this->parse_link_header( $response->headers['link'] );
+			}
+
+			if ( ! empty( $links['next'] ) ) {
+				$response = Requests::get( $links['next'] );
+			}
+
+			$page ++;
+		}
+
+		return $terms;
+	}
+
+	/**
+	 * Get data about taxonomies from a REST API endpoint.
+	 *
+	 * @return array
+	 */
+	public function get_post_types() {
+		$endpoint = $this->endpoint_base . 'types';
+
+		$response = Requests::get( $endpoint );
+
+		if ( 200 !== $response->status_code ) {
+			die( 'Could not retrieve taxonomy data.' );
+		}
+
+		$types = json_decode( $response->body, true );
+
+		if ( ! is_array( $types ) ) {
+			die( 'Taxonomies request returned unexpected data.' );
+		}
+
+		$types = array_filter(
+			$types,
+			function( $type ) {
+				return in_array( $type['slug'], $this->valid_post_types, true );
+			}
+		);
+
+		return $types;
+	}
+
+	/**
+	 * Get data about posts (of a specific type) from a REST API endpoint.
+	 *
+	 * @return array
+	 */
+	public function get_posts( $post_type ) {
+		$endpoint    = $this->endpoint_base . $post_type['rest_base'] . '?per_page=100';
+		$posts       = array();
+		$page        = 1;
+		$total_pages = 1;
+
+		$response  = Requests::get( $endpoint );
+
+		if ( isset( $response->headers['x-wp-totalpages'] ) ) {
+			$total_pages = intval( $response->headers['x-wp-totalpages'] );
+		}
+
+		while ( $page <= $total_pages ) {
+			if ( 'cli' === php_sapi_name() ) {
+				echo sprintf(
+					"Page %d... \n",
+					$page // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				);
+			}
+
+			if ( 200 !== $response->status_code ) {
+				die(
+					sprintf(
+						'Could not retrieve posts for %s.',
+						$post_type['slug'] // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					)
+				);
+			}
+
+			$more_posts = json_decode( $response->body, true );
+
+			if ( ! is_array( $more_posts ) ) {
+				die(
+					sprintf(
+						'Posts request for %s returned unexpected data.',
+						$post_type['slug'] // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					)
+				);
+			}
+
+			$posts = array_merge( $posts, $more_posts );
+
+			$links = array();
+			if ( isset( $response->headers['link'] ) ) {
+				$links = $this->parse_link_header( $response->headers['link'] );
+			}
+
+			if ( ! empty( $links['next'] ) ) {
+				$response = Requests::get( $links['next'] );
+			}
+
+			$page++;
+		}
+
+		return $posts;
+	}
+
+	/**
+	 * Parse a link header from a WP REST API response into an array of prev/next URLs.
+	 *
+	 * @param string $link_header
+	 *
+	 * @return array Associative array of links, with possible keys of next and prev, values are URLs.
+	 */
+	public function parse_link_header( $link_header ) {
+		$links = explode( ',', $link_header );
+
+		return array_reduce(
+			$links,
+			function( $carry, $item ) {
+				$split = explode( ';', trim( $item ) );
+				preg_match( '|<([^<>]+)>|', $split[0], $url );
+				preg_match( '|rel="([^"]+)"|', $split[1], $rel );
+
+				if ( ! empty( $url[1] ) && ! empty( $rel[1] ) ) {
+					$carry[ $rel[1] ] = filter_var( $url[1], FILTER_VALIDATE_URL );
+				}
+
+				return $carry;
+			},
+			array()
+		);
+	}
+
+	/**
+	 * Run the script.
+	 */
+	public function main() {
+		if ( 'cli' === php_sapi_name() ) {
+			echo "\n";
+			echo "Retrieving taxonomies...\n";
+		}
+
+		$taxonomies = $this->get_taxonomies();
+
+		if ( 'cli' === php_sapi_name() ) {
+			echo "Retrieving terms...\n";
+		}
+
+		$terms_by_tax = array();
+		foreach ( $taxonomies as $taxonomy ) {
+			if ( 'cli' === php_sapi_name() ) {
+				echo sprintf(
+					'%s... ',
+					$taxonomy['name'] // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				);
+			}
+
+			$terms = $this->get_taxonomy_terms( $taxonomy );
+
+			if ( 'cli' === php_sapi_name() ) {
+				echo "\n";
+			}
+
+			if ( count( $terms ) > 0 ) {
+				$terms_by_tax[ $taxonomy['name'] ] = $terms;
+			}
+
+			unset( $terms );
+		}
+
+		if ( 'cli' === php_sapi_name() ) {
+			echo "\n";
+		}
+
+		$file_content = '';
+		foreach ( $terms_by_tax as $tax_label => $terms ) {
+			$label = addcslashes( $tax_label, "'" );
+
+			foreach ( $terms as $term ) {
+				$name = addcslashes( $term['name'], "'" );
+				$file_content .= "_x( '{$name}', '$label term name', 'wporg-patterns' );\n";
+
+				if ( 'cli' === php_sapi_name() ) {
+					echo "$name\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				}
+
+				if ( $term['description'] ) {
+					$description = addcslashes( $term['description'], "'" );
+					$file_content .= "_x( '{$description}', '$label term description', 'wporg-patterns' );\n";
+				}
+			}
+		}
+
+		if ( 'cli' === php_sapi_name() ) {
+			echo "\n";
+			echo "Retrieving post types...\n";
+		}
+
+		$post_types = $this->get_post_types();
+
+		foreach( $post_types as $post_type ) {
+			if ( 'cli' === php_sapi_name() ) {
+				echo "\n";
+				echo sprintf(
+					"Retrieving %s...\n",
+					$post_type['name']
+				);
+			}
+
+			foreach ( $this->get_posts( $post_type ) as $page ) {
+				$title = addcslashes( $page['title']['rendered'], "'" );
+				$file_content .= "_x( '{$title}', 'Page title', 'wporg-patterns' );\n";
+
+				if ( 'cli' === php_sapi_name() ) {
+					echo "$title\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				}
+			}
+		}
+
+		$path = get_workspace_path() . '/extra';
+		if ( ! is_writeable( $path ) ) {
+			mkdir( $path );
+		}
+
+		$file_name = 'translation-strings.php';
+		$file_header = <<<HEADER
+<?php
+/**
+ * Generated file for translation strings.
+ *
+ * Used to import additional strings into the pattern-directory translation project.
+ *
+ * ⚠️ This is a generated file. Do not edit manually. See bin/i18n.php.
+ * ⚠️ Do not require or include this file anywhere.
+ */
+
+
+HEADER;
+
+		file_put_contents( $path . '/' . $file_name, $file_header . $file_content );
+
+		echo $file_header . $file_content;
+
+		if ( 'cli' === php_sapi_name() ) {
+			echo "\n";
+			echo "Done.\n";
+		}
+	}
+}
+
+$runner = new Generate_Translation_Strings();
+$runner->main();

--- a/.github/actions/i18n/bin/i18n.php
+++ b/.github/actions/i18n/bin/i18n.php
@@ -39,10 +39,18 @@ class Generate_Translation_Strings {
 	public $valid_post_types = array( 'post', 'page' );
 
 	/**
+	 * The textdomain to use.
+	 *
+	 * @var string $textdomain
+	 */
+	public $textdomain = 'wporg';
+
+	/**
 	 * Initialze the class, set up the properties based on CLI args.
 	 */
 	public function __construct() {
-		$args = getopt( '', [ 'url::', 'taxonomies::', 'no_taxonomies', 'post_types::', 'no_post_types' ] );
+		$options = array( 'url::', 'taxonomies::', 'no_taxonomies', 'post_types::', 'no_post_types', 'textdomain::' );
+		$args = getopt( '', $options );
 
 		if ( ! empty( $args['url'] ) && filter_var( $args['url'], FILTER_VALIDATE_URL ) ) {
 			$this->endpoint_base = $args['url'];
@@ -62,6 +70,19 @@ class Generate_Translation_Strings {
 
 		if ( isset( $args['no_post_types'] ) ) {
 			$this->valid_post_types = array();
+		}
+
+		if ( ! empty( $args['textdomain'] ) ) {
+			// Pulled from `sanitize_title_with_dashes`.
+			$textdomain = strip_tags( $args['textdomain'] );
+			$textdomain = strtolower( $textdomain );
+			$textdomain = preg_replace( '/&.+?;/', '', $textdomain );
+			$textdomain = str_replace( '.', '-', $textdomain );
+			$textdomain = preg_replace( '/[^%a-z0-9 _-]/', '', $textdomain );
+			$textdomain = preg_replace( '/\s+/', '-', $textdomain );
+			$textdomain = preg_replace( '|-+|', '-', $textdomain );
+			$textdomain = trim( $textdomain, '-' );
+			$this->textdomain = $textdomain;
 		}
 	}
 
@@ -325,7 +346,7 @@ class Generate_Translation_Strings {
 
 			foreach ( $terms as $term ) {
 				$name = addcslashes( $term['name'], "'" );
-				$file_content .= "_x( '{$name}', '$label term name', 'wporg-patterns' );\n";
+				$file_content .= "_x( '{$name}', '$label term name', '{$this->textdomain}' );\n";
 
 				if ( 'cli' === php_sapi_name() ) {
 					echo "$name\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
@@ -333,7 +354,7 @@ class Generate_Translation_Strings {
 
 				if ( $term['description'] ) {
 					$description = addcslashes( $term['description'], "'" );
-					$file_content .= "_x( '{$description}', '$label term description', 'wporg-patterns' );\n";
+					$file_content .= "_x( '{$description}', '$label term description', '{$this->textdomain}' );\n";
 				}
 			}
 		}
@@ -356,7 +377,7 @@ class Generate_Translation_Strings {
 
 			foreach ( $this->get_posts( $post_type ) as $page ) {
 				$title = addcslashes( $page['title']['rendered'], "'" );
-				$file_content .= "_x( '{$title}', 'Page title', 'wporg-patterns' );\n";
+				$file_content .= "_x( '{$title}', 'Post title', '{$this->textdomain}' );\n";
 
 				if ( 'cli' === php_sapi_name() ) {
 					echo "$title\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,6 @@
 		"bin/update-configs"
 	],
 	"require": {
-        "rmccue/requests": "1.8.1"
-    }
+		"rmccue/requests": "1.8.1"
+	}
 }

--- a/composer.json
+++ b/composer.json
@@ -8,5 +8,8 @@
 	},
 	"bin": [
 		"bin/update-configs"
-	]
+	],
+	"require": {
+        "rmccue/requests": "1.8.1"
+    }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,79 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "a88f20f89fcdd55909e646805ff1dd97",
+    "packages": [
+        {
+            "name": "rmccue/requests",
+            "version": "v1.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress/Requests.git",
+                "reference": "82e6936366eac3af4d836c18b9d8c31028fe4cd5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress/Requests/zipball/82e6936366eac3af4d836c18b9d8c31028fe4cd5",
+                "reference": "82e6936366eac3af4d836c18b9d8c31028fe4cd5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+                "php-parallel-lint/php-console-highlighter": "^0.5.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5 || ^7.5",
+                "requests/test-server": "dev-master",
+                "squizlabs/php_codesniffer": "^3.5",
+                "wp-coding-standards/wpcs": "^2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Requests": "library/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Ryan McCue",
+                    "homepage": "http://ryanmccue.info"
+                }
+            ],
+            "description": "A HTTP library written in PHP, for human beings.",
+            "homepage": "http://github.com/WordPress/Requests",
+            "keywords": [
+                "curl",
+                "fsockopen",
+                "http",
+                "idna",
+                "ipv6",
+                "iri",
+                "sockets"
+            ],
+            "support": {
+                "issues": "https://github.com/WordPress/Requests/issues",
+                "source": "https://github.com/WordPress/Requests/tree/v1.8.1"
+            },
+            "time": "2021-06-04T09:56:25+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.3.0"
+}


### PR DESCRIPTION
See https://github.com/WordPress/wporg-theme-directory/issues/74, https://github.com/WordPress/wporg-main-2022/issues/436 — the content coming from the WordPress database is not translated on rosetta sites. We had a similar problem on Patterns and Learn, so they both use this sync-script process to get the strings into GlotPress (https://github.com/WordPress/pattern-directory/pull/275). Since this has now also come up on the main site and themes, I've created a shared action that should accept args to pull the correct project's strings into the repo.

The script scrapes the API for taxonomy terms and post types, pulls down the term titles, descriptions, and post titles. Those are then injected into a php file with i18n wrappers, so that this can be loaded into the regular translation syncing process.

It can be used in a child theme project's actions like this:

<details>
<summary>Example workflow file</summary>

```
name: Translate Strings

on:
  workflow_dispatch:
  schedule:
    - cron: '0 6,18 * * *'

jobs:
  translation-strings:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout repository
        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3

      - name: i18n
        uses: WordPress/wporg-repo-tools/.github/actions/i18n@try/i18n-action
        with:
          token: ${{ secrets.GITHUB_TOKEN }}
          args: --no_taxonomies

      - name: Commit and push
        # Using a specific hash here instead of a tagged version, for risk mitigation, since this action modifies our repo.
        uses: actions-js/push@a52398fac807b0c1e5f1492c969b477c8560a0ba # 1.3
        with:
            github_token: ${{ secrets.GITHUB_TOKEN }}
            branch: test-i18n
            message: 'Update translation strings'
```

</details>

I've got a testing branch on my wporg-main-2022 fork here: https://github.com/WordPress/wporg-main-2022/compare/trunk...ryelle:wporg-main-2022:test-i18n

The last commit there includes the `translate-strings.php` file with all the page titles from WordPress.org.

This can also be tested locally, if you want to try out different args

- `composer install` to get the Requests dep
- `php .github/actions/i18n/bin/i18n.php --taxonomies=wporg-pattern-category,wporg-pattern-flag-reason --post_types=page --url=https://wordpress.org/patterns/wp-json/wp/v2/`
- The CLI output describes what's happening, and you should end up with a `extra/translation-strings.php` file.

Still to do:

- [x] Don't commit the composer changes in the child project
- [x] Pass through the textdomain, so it's not always `wporg-patterns`

Not part of this PR, but will need to add filters to actually _use_ the translated values.