### PR TITLE
Configs: Switch to inheriting stylistic rules for stylelint compatibility

### DIFF
--- a/configs/.stylelintrc
+++ b/configs/.stylelintrc
@@ -1,7 +1,7 @@
 {
-	"extends" : "@wordpress/stylelint-config/scss",
+	"extends" : "@wordpress/stylelint-config/scss-stylistic",
 	"rules"   : {
-		"max-line-length": 115,
+		"@stylistic/max-line-length": 115,
 		"no-descending-specificity": null,
 		"rule-empty-line-before" : [ "always-multi-line", {
 			"except" : [ "first-nested", "after-single-line-comment" ]


### PR DESCRIPTION
In [wp-scripts 30.0.0](https://github.com/WordPress/gutenberg/blob/0decb96f74ca03cddb64f0ccb40f2067f43626bd/packages/scripts/CHANGELOG.md#3000-2024-09-19), the stylelint dependency was updated to ^16.8.2. The stylistic rules (e.g., `max-line-length`) were [deprecated in v 15.0](https://stylelint.io/migration-guide/to-15#deprecated-stylistic-rules), and fully removed in 16.0. They've been moved to a new package `@stylistic/stylelint-config`, and wp-scripts uses that now to set up the style rules with a new ruleset `@wordpress/stylelint-config/scss-stylistic`.

This updates our `.stylelintrc` file to use this new ruleset, and use the `@stylistic` version of max-line-length.

On a repo with `@wordpress/scripts >= 30`

- Copy this `.stylelintrc` into the project
- Run `wp-scripts lint-style […files]`
- It should pass 👍🏻 

Without this PR, you'll see an error:

```
src/style/style.scss
  1:1  ✖  Unknown rule max-line-length  max-line-length

✖ 1 problem (1 error, 0 warnings)
```

For repos that are still on older versions of wp-scripts, they should be updated before `update:tools` is run, otherwise we'll have the inverse issue with the new rule being unknown.