### PR TITLE
Conditionally run php if we have a configuration.

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -15,4 +15,4 @@ runs:
     - name: Lint PHP
       shell: bash
       run: yarn lint:php
-      if: fileExists('phpcs.xml')
+      if: ${{ files.exists('phpcs.xml') }}

--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -15,4 +15,4 @@ runs:
     - name: Lint PHP
       shell: bash
       run: yarn lint:php
-      if: ${{ files.exists('phpcs.xml') }}
+      if: ${{ hashFiles('phpcs.xml') != '' }}

--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -15,3 +15,4 @@ runs:
     - name: Lint PHP
       shell: bash
       run: yarn lint:php
+      if: fileExists('phpcs.xml')


### PR DESCRIPTION
This PR changes the linting action to only run when `phpcs` is present so we can use it with the parent theme which doesn't include any PHP. That PR exists here: https://github.com/WordPress/wporg-parent-2021/pull/166.