### PR TITLE
Update to PHP 8.1 and refresh all dependencies

### DIFF
--- a/.github/actions/i18n/action.yml
+++ b/.github/actions/i18n/action.yml
@@ -21,9 +21,9 @@ runs:
         sudo apt install subversion
 
     - name: Setup PHP with PECL extension
-      uses: shivammathur/setup-php@4bd44f22a98a19e0950cbad5f31095157cc9621b # v2.25.4 
+      uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2.36.0
       with:
-        php-version: "7.4"
+        php-version: "8.1"
       env:
         COMPOSER_TOKEN: ${{ inputs.token }}
 
@@ -31,7 +31,6 @@ runs:
       shell: bash
       run: |
         composer install || composer update wporg/*
-        composer require rmccue/requests:1.8.1
 
     - name: Run translation script
       shell: bash

--- a/.github/actions/i18n/bin/i18n.php
+++ b/.github/actions/i18n/bin/i18n.php
@@ -3,8 +3,6 @@
 
 namespace WordPressdotorg\Repo_Tools\Bin\I18N;
 
-use Requests;
-
 function get_workspace_path() {
 	$workspace_path = getenv( 'GITHUB_WORKSPACE' );
 	if ( ! $workspace_path ) {
@@ -13,7 +11,44 @@ function get_workspace_path() {
 	return $workspace_path;
 }
 
-require_once get_workspace_path() . '/vendor/autoload.php';
+/**
+ * Perform an HTTP GET request using file_get_contents.
+ *
+ * @param string $url The URL to fetch.
+ *
+ * @return object Object with status_code, body, and headers properties.
+ */
+function http_get( $url ) {
+	$context = stream_context_create(
+		[
+			'http' => [
+				'user_agent'      => 'WordPress.org Repo Tools/1.0; https://github.com/WordPress/wporg-repo-tools',
+				'ignore_errors'   => true,
+			],
+		]
+	);
+
+	$body        = file_get_contents( $url, false, $context );
+	$status_code = 0;
+	$headers     = [];
+
+	if ( isset( $http_response_header ) ) {
+		foreach ( $http_response_header as $header ) {
+			if ( preg_match( '|^HTTP/\S+\s+(\d+)|', $header, $match ) ) {
+				$status_code = intval( $match[1] );
+			} elseif ( str_contains( $header, ':' ) ) {
+				[ $key, $value ]                    = explode( ':', $header, 2 );
+				$headers[ strtolower( trim( $key ) ) ] = trim( $value );
+			}
+		}
+	}
+
+	return (object) [
+		'status_code' => $status_code,
+		'body'        => $body,
+		'headers'     => $headers,
+	];
+}
 
 class Generate_Translation_Strings {
 
@@ -94,7 +129,7 @@ class Generate_Translation_Strings {
 	public function get_taxonomies() {
 		$endpoint = $this->endpoint_base . 'taxonomies';
 
-		$response = Requests::get( $endpoint );
+		$response = http_get( $endpoint );
 
 		if ( 200 !== $response->status_code ) {
 			die( 'Could not retrieve taxonomy data.' );
@@ -129,7 +164,7 @@ class Generate_Translation_Strings {
 		$page        = 1;
 		$total_pages = 1;
 
-		$response = Requests::get( $endpoint );
+		$response = http_get( $endpoint );
 
 		if ( isset( $response->headers['x-wp-totalpages'] ) ) {
 			$total_pages = intval( $response->headers['x-wp-totalpages'] );
@@ -171,7 +206,7 @@ class Generate_Translation_Strings {
 			}
 
 			if ( ! empty( $links['next'] ) ) {
-				$response = Requests::get( $links['next'] );
+				$response = http_get( $links['next'] );
 			}
 
 			$page ++;
@@ -188,7 +223,7 @@ class Generate_Translation_Strings {
 	public function get_post_types() {
 		$endpoint = $this->endpoint_base . 'types';
 
-		$response = Requests::get( $endpoint );
+		$response = http_get( $endpoint );
 
 		if ( 200 !== $response->status_code ) {
 			die( 'Could not retrieve taxonomy data.' );
@@ -221,7 +256,7 @@ class Generate_Translation_Strings {
 		$page        = 1;
 		$total_pages = 1;
 
-		$response  = Requests::get( $endpoint );
+		$response  = http_get( $endpoint );
 
 		if ( isset( $response->headers['x-wp-totalpages'] ) ) {
 			$total_pages = intval( $response->headers['x-wp-totalpages'] );
@@ -263,7 +298,7 @@ class Generate_Translation_Strings {
 			}
 
 			if ( ! empty( $links['next'] ) ) {
-				$response = Requests::get( $links['next'] );
+				$response = http_get( $links['next'] );
 			}
 
 			$page++;

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -22,15 +22,15 @@ runs:
         sudo apt install subversion
 
     - name: Install NodeJS
-      uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version-file: ".nvmrc"
         cache: ${{ inputs.packageManager }}
 
     - name: Setup PHP with PECL extension
-      uses: shivammathur/setup-php@4bd44f22a98a19e0950cbad5f31095157cc9621b # v2.25.4 
+      uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2.36.0
       with:
-        php-version: "7.4"
+        php-version: "8.1"
       env:
         COMPOSER_TOKEN: ${{ inputs.token }}
 

--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,5 @@
 	},
 	"bin": [
 		"bin/update-configs"
-	],
-	"require": {
-		"rmccue/requests": "1.8.1"
-	}
+	]
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,76 +4,15 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a88f20f89fcdd55909e646805ff1dd97",
-    "packages": [
-        {
-            "name": "rmccue/requests",
-            "version": "v1.8.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/WordPress/Requests.git",
-                "reference": "82e6936366eac3af4d836c18b9d8c31028fe4cd5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/Requests/zipball/82e6936366eac3af4d836c18b9d8c31028fe4cd5",
-                "reference": "82e6936366eac3af4d836c18b9d8c31028fe4cd5",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.2"
-            },
-            "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
-                "php-parallel-lint/php-console-highlighter": "^0.5.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3",
-                "phpcompatibility/php-compatibility": "^9.0",
-                "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5 || ^7.5",
-                "requests/test-server": "dev-master",
-                "squizlabs/php_codesniffer": "^3.5",
-                "wp-coding-standards/wpcs": "^2.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "Requests": "library/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "ISC"
-            ],
-            "authors": [
-                {
-                    "name": "Ryan McCue",
-                    "homepage": "http://ryanmccue.info"
-                }
-            ],
-            "description": "A HTTP library written in PHP, for human beings.",
-            "homepage": "http://github.com/WordPress/Requests",
-            "keywords": [
-                "curl",
-                "fsockopen",
-                "http",
-                "idna",
-                "ipv6",
-                "iri",
-                "sockets"
-            ],
-            "support": {
-                "issues": "https://github.com/WordPress/Requests/issues",
-                "source": "https://github.com/WordPress/Requests/tree/v1.8.1"
-            },
-            "time": "2021-06-04T09:56:25+00:00"
-        }
-    ],
+    "content-hash": "cb061a43a104cd06ba37fec924c3b7ee",
+    "packages": [],
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/configs/.stylelintrc
+++ b/configs/.stylelintrc
@@ -1,7 +1,7 @@
 {
 	"extends" : "@wordpress/stylelint-config/scss",
 	"rules"   : {
-		"max-line-length": 115,
+		"@stylistic/max-line-length": 115,
 		"no-descending-specificity": null,
 		"rule-empty-line-before" : [ "always-multi-line", {
 			"except" : [ "first-nested", "after-single-line-comment" ]

--- a/configs/phpcs.xml.dist
+++ b/configs/phpcs.xml.dist
@@ -58,7 +58,7 @@
     </rule>
 
     <rule ref="PHPCompatibilityWP">
-        <config name="testVersion" value="7.4-" />
+        <config name="testVersion" value="8.1-" />
     </rule>
 
     <!-- Custom project rules go here -->

--- a/templates/composer.json.template
+++ b/templates/composer.json.template
@@ -7,7 +7,7 @@
 	},
 	"config": {
 		"platform": {
-			"php": "7.4"
+			"php": "8.1"
 		},
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true
@@ -15,11 +15,11 @@
 	},
 	"require": {},
 	"require-dev" : {
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-		"wp-coding-standards/wpcs": "2.3.*",
-		"phpunit/phpunit": "^9.5",
-		"spatie/phpunit-watcher": "^1.23",
-		"yoast/phpunit-polyfills": "^1.0"
+		"dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+		"wp-coding-standards/wpcs": "^3.0",
+		"phpunit/phpunit": "^10.5",
+		"spatie/phpunit-watcher": "^1.24",
+		"yoast/phpunit-polyfills": "^2.0"
 	},
 	"scripts": {
 		"lint": "phpcs --extensions=php -s -p",

--- a/templates/package.json.template
+++ b/templates/package.json.template
@@ -7,9 +7,9 @@
 	"private": true,
 	"dependencies": {},
 	"devDependencies": {
-		"@wordpress/browserslist-config": "^4.1.2",
-		"@wordpress/env": "^4.6.0",
-		"@wordpress/scripts": "^22.5.0"
+		"@wordpress/browserslist-config": "^6.0.0",
+		"@wordpress/env": "^11.0.0",
+		"@wordpress/scripts": "^31.0.0"
 	},
 	"scripts": {
 		"setup:tools": "yarn && composer install && TEXTDOMAIN=wporg composer exec update-configs",


### PR DESCRIPTION
## Summary
- Bumps minimum PHP version from 7.4 to 8.1 across GitHub Actions, templates, and PHPCS config
- Updates all GitHub Actions (`setup-node` v3→v4, `setup-php` v2.25→v2.36)
- Updates PHP template dependencies (WPCS 3.x, PHPUnit 10.x, and related packages)
- Updates Node template dependencies (`@wordpress/env`, `@wordpress/scripts`, `@wordpress/browserslist-config`)
- Removes `rmccue/requests` dependency — replaces with `file_get_contents()` using a custom user-agent in the i18n script

## Test plan
- [ ] Verify dependent repos can run the `setup` action with PHP 8.1
- [ ] Verify the `i18n` action still generates translation strings correctly without the Requests library
- [ ] Verify `composer install` works with the updated template on a fresh project
- [ ] Verify `npm install` / `yarn` works with the updated package.json template

🤖 Generated with [Claude Code](https://claude.com/claude-code)