### PR TITLE
Add import/no-unresolved ignore for @wordpress packages

### DIFF
--- a/configs/.eslintrc.js
+++ b/configs/.eslintrc.js
@@ -23,6 +23,11 @@ module.exports = {
 
 	rules: {
 		/*
+		 * WordPress packages are script dependencies provided at runtime, not installed via npm.
+		 */
+		'import/no-unresolved': [ 'error', { ignore: [ '^@wordpress/' ] } ],
+
+		/*
 		 * Set up our text domain.
 		 */
 		'@wordpress/i18n-text-domain': [ 'error', { allowedTextDomain: [ '${TEXTDOMAIN}' ] } ],


### PR DESCRIPTION
## Summary

- Adds `import/no-unresolved` rule override to ignore `@wordpress/*` imports in the shared eslint config

## Problem

`@wordpress/eslint-plugin` v24+ (bundled with `@wordpress/scripts` v31+) enables `import/no-unresolved: error` by default via its `recommended-with-formatting` config. WordPress packages (`@wordpress/blocks`, `@wordpress/block-editor`, etc.) are script dependencies provided by WordPress at runtime and are not installed as npm packages, so they fail this check.

This is currently breaking JS lint in repos that have updated their `@wordpress/scripts` dependency (e.g., wporg-main-2022).

## Test plan

- [ ] Verify JS lint passes in wporg-main-2022 after this change is merged

Generated with [Claude Code](https://claude.com/claude-code)