### PR TITLE
Use modern PHPCS array property syntax for text_domain

### DIFF
--- a/configs/phpcs.xml.dist
+++ b/configs/phpcs.xml.dist
@@ -49,11 +49,12 @@
         <exclude name="Squiz.Commenting.InlineComment.NoSpaceBefore" />
     </rule>
 
-    <!-- Verify that the text_domain is set to the desired text-domain. Multiple valid text domains can be
-         provided as a comma-delimited list. -->
+    <!-- Verify that the text_domain is set to the desired text-domain. -->
     <rule ref="WordPress.WP.I18n">
         <properties>
-            <property name="text_domain" type="array" value="${TEXTDOMAIN}" />
+            <property name="text_domain" type="array">
+                <element value="${TEXTDOMAIN}" />
+            </property>
         </properties>
     </rule>
 


### PR DESCRIPTION
## Summary

- Updates `phpcs.xml.dist` to use the modern element child syntax for the `text_domain` array property

## Problem

PHPCS 3.3.0 deprecated passing array values via comma-separated strings in the `value` attribute. The current syntax:

```xml
<property name="text_domain" type="array" value="${TEXTDOMAIN}" />
```

Triggers a deprecation warning:
> DEPRECATED: Passing an array of values to a property using a comma-separated string was deprecated in PHP_CodeSniffer 3.3.0. Support will be removed in PHPCS 4.0.0.

The fix uses the modern element child syntax:
```xml
<property name="text_domain" type="array">
    <element value="${TEXTDOMAIN}" />
</property>
```

## Test plan

- [ ] Verify PHPCS lint runs without deprecation warnings

Generated with [Claude Code](https://claude.com/claude-code)