### PR TITLE
Add skip-build parameter to setup action

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -11,6 +11,11 @@ inputs:
     type: string
     required: false
     default: "yarn"
+  skip-build:
+    description: "Skip the build step"
+    type: string
+    required: false
+    default: "false"
 
 
 runs:
@@ -44,7 +49,7 @@ runs:
 
     - name: Build all included projects (yarn)
       shell: bash
-      if: ${{ 'yarn' == inputs.packageManager }}
+      if: ${{ inputs.packageManager == 'yarn' && inputs.skip-build != 'true' }}
       run: yarn workspaces run build
 
     - name: Install all dependencies (npm)
@@ -57,5 +62,5 @@ runs:
 
     - name: Build all included projects (npm)
       shell: bash
-      if: ${{ 'npm' == inputs.packageManager }}
+      if: ${{ inputs.packageManager == 'npm' && inputs.skip-build != 'true' }}
       run: npm run build --workspaces --if-present


### PR DESCRIPTION
## Summary
- Adds a `skip-build` input parameter (default: `false`) to the shared setup action
- When `true`, skips the `yarn workspaces run build` / `npm run build` step
- Useful for workflows that only need dependencies installed (e.g. content-update in wporg-main-2022)

## Usage
```yaml
- name: Setup
  uses: WordPress/wporg-repo-tools/.github/actions/setup@trunk
  with:
    token: ${{ secrets.GITHUB_TOKEN }}
    skip-build: true
```

Companion PR: https://github.com/WordPress/wporg-main-2022/pull/645

🤖 Generated with [Claude Code](https://claude.com/claude-code)