### PR TITLE
Add wp-env-config input to test-php action

### DIFF
--- a/.github/actions/test-php/action.yml
+++ b/.github/actions/test-php/action.yml
@@ -1,12 +1,18 @@
 name: "PHP Unit Tests"
 description: "Run the php unit tests"
 
+inputs:
+  wp-env-config:
+    description: "Path to a custom wp-env config file (passed as --config to wp-env)"
+    required: false
+    default: ""
+
 runs:
   using: "composite"
   steps:
     - name: Install WordPress
       shell: bash
-      run: yarn wp-env start
+      run: yarn wp-env ${{ inputs.wp-env-config && format('--config {0}', inputs.wp-env-config) }} start
 
     - name: Running PHP unit tests
       shell: bash


### PR DESCRIPTION
## Summary
- Adds optional `wp-env-config` input to the `test-php` shared action
- When provided, passes `--config <value>` to `wp-env start`
- Allows consuming repos to use separate wp-env configs for testing (e.g. on a different port, without test containers in the main config)

## Usage
```yaml
- name: Test
  uses: WordPress/wporg-repo-tools/.github/actions/test-php@trunk
  with:
    wp-env-config: .wp-env.test.json
```

Companion PR: https://github.com/WordPress/wporg-main-2022/pull/645

## Test plan
- [ ] Verify existing repos without `wp-env-config` still work (defaults to empty, no `--config` flag passed)
- [ ] Verify wporg-main-2022 phpunit workflow passes with `wp-env-config: .wp-env.test.json`

Generated with [Claude Code](https://claude.com/claude-code)