### PR TITLE
Update PHP version from 8.1 to 8.4

### DIFF
--- a/.github/actions/i18n/action.yml
+++ b/.github/actions/i18n/action.yml
@@ -23,7 +23,7 @@ runs:
     - name: Setup PHP with PECL extension
       uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2.36.0
       with:
-        php-version: "8.1"
+        php-version: "8.4"
       env:
         COMPOSER_TOKEN: ${{ inputs.token }}
 

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -35,7 +35,7 @@ runs:
     - name: Setup PHP with PECL extension
       uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2.36.0
       with:
-        php-version: "8.1"
+        php-version: "8.4"
       env:
         COMPOSER_TOKEN: ${{ inputs.token }}
 

--- a/configs/phpcs.xml.dist
+++ b/configs/phpcs.xml.dist
@@ -59,7 +59,7 @@
     </rule>
 
     <rule ref="PHPCompatibilityWP">
-        <config name="testVersion" value="8.1-" />
+        <config name="testVersion" value="8.4-" />
     </rule>
 
     <!-- Custom project rules go here -->

--- a/templates/composer.json.template
+++ b/templates/composer.json.template
@@ -7,7 +7,7 @@
 	},
 	"config": {
 		"platform": {
-			"php": "8.1"
+			"php": "8.4"
 		},
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true


### PR DESCRIPTION
## Summary

As part of the ongoing WordPress.org PHP 8.4 upgrade, this updates all PHP version references in the shared repo tools:

- **setup action**: PHP version for `shivammathur/setup-php` updated to 8.4
- **i18n action**: PHP version for `shivammathur/setup-php` updated to 8.4
- **composer.json template**: Platform PHP version updated to 8.4
- **phpcs.xml.dist**: PHPCompatibilityWP `testVersion` updated to 8.4-

## Test plan

- [ ] Verify downstream repos using these shared actions build and test successfully with PHP 8.4
- [ ] Confirm PHPCS compatibility checks target PHP 8.4+

🤖 Generated with [Claude Code](https://claude.com/claude-code)