### PR TITLE
Actions: Remove COMPOSER_AUTH workaround now that composer 2.9.8 is out

### DIFF
--- a/.github/actions/i18n/action.yml
+++ b/.github/actions/i18n/action.yml
@@ -20,24 +20,15 @@ runs:
       run: |
         sudo apt install subversion
 
-    # The github-token input is blanked so setup-php does not write a
-    # github-oauth entry to ~/.composer/auth.json. With a JWT-format
-    # GITHUB_TOKEN, that entry trips composer's BaseIO validator (it
-    # rejects `-` in the token's base64url signature segment).
-    # See https://github.com/composer/composer/issues/12849.
-    # Composer authentication is provided via COMPOSER_AUTH on the
-    # composer step below, which uses http-basic and is not subject to
-    # that regex.
     - name: Setup PHP with PECL extension
       uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2.37.0
       with:
         php-version: "8.4"
-        github-token: ""
+      env:
+        COMPOSER_TOKEN: ${{ inputs.token }}
 
     - name: Install composer dependencies
       shell: bash
-      env:
-        COMPOSER_AUTH: '{"http-basic":{"github.com":{"username":"x-access-token","password":"${{ inputs.token }}"}}}'
       run: |
         composer install || composer update wporg/*
 

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -32,25 +32,16 @@ runs:
         node-version-file: ".nvmrc"
         cache: ${{ inputs.packageManager }}
 
-    # The github-token input is blanked so setup-php does not write a
-    # github-oauth entry to ~/.composer/auth.json. With a JWT-format
-    # GITHUB_TOKEN, that entry trips composer's BaseIO validator (it
-    # rejects `-` in the token's base64url signature segment).
-    # See https://github.com/composer/composer/issues/12849.
-    # Composer authentication is provided via the COMPOSER_AUTH env on
-    # the composer steps below, which uses http-basic and is not
-    # subject to that regex.
     - name: Setup PHP with PECL extension
       uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2.37.0
       with:
         php-version: "8.4"
-        github-token: ""
+      env:
+        COMPOSER_TOKEN: ${{ inputs.token }}
 
     - name: Install all dependencies (yarn)
       shell: bash
       if: ${{ 'yarn' == inputs.packageManager }}
-      env:
-        COMPOSER_AUTH: '{"http-basic":{"github.com":{"username":"x-access-token","password":"${{ inputs.token }}"}}}'
       run: |
         composer install || composer update wporg/*
         yarn
@@ -64,8 +55,6 @@ runs:
     - name: Install all dependencies (npm)
       shell: bash
       if: ${{ 'npm' == inputs.packageManager }}
-      env:
-        COMPOSER_AUTH: '{"http-basic":{"github.com":{"username":"x-access-token","password":"${{ inputs.token }}"}}}'
       run: |
         composer install || composer update wporg/*
         npm install


### PR DESCRIPTION
## Summary
- Composer 2.9.8 fixed [composer/composer#12849](https://github.com/composer/composer/issues/12849) by updating the BaseIO github-oauth regex from `{^[.A-Za-z0-9_]+$}` to `{^[.A-Za-z0-9_-]+$}`. JWT-format `GITHUB_TOKEN` values (which include `-` in the base64url signature segment) now pass validation.
- `shivammathur/setup-php` installs the latest stable composer at action runtime, so every consumer of these actions is already on 2.9.8+.
- Revert the `COMPOSER_AUTH`/`github-token: ""` workaround from #40 and restore the simpler `COMPOSER_TOKEN` env path.
- `setup-php` is intentionally left at the v2.37.0 SHA the workaround introduced — that bump is independent and worth keeping.

## Test plan
- [ ] `validate-actions` workflow runs the setup, lint, i18n, and test-php jobs against the consumer fixture with the auth simplification — they should remain green.
