### PR TITLE
Actions: bump PHP minimum to 8.4 and run tests on 8.4 + 8.5

### DIFF
--- a/.github/actions/i18n/action.yml
+++ b/.github/actions/i18n/action.yml
@@ -12,6 +12,12 @@ inputs:
     required: false
     type: string
 
+  php-version:
+    description: "PHP version to install on the runner."
+    required: false
+    type: string
+    default: "8.4"
+
 runs:
   using: "composite"
   steps:
@@ -23,7 +29,7 @@ runs:
     - name: Setup PHP with PECL extension
       uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2.37.0
       with:
-        php-version: "8.4"
+        php-version: ${{ inputs.php-version }}
       env:
         COMPOSER_TOKEN: ${{ inputs.token }}
 

--- a/.github/actions/readme.md
+++ b/.github/actions/readme.md
@@ -40,11 +40,12 @@ For example, to run the PHP Unit Tests action, add this to your workflow.
   uses: WordPress/wporg-repo-tools/.github/actions/test-php
 ```
 
-The setup action accepts one input. The `token` is required for composer to install the dependencies (the secrets are not passed through otherwise).
+The setup action accepts a few inputs. `token` is required for composer to install the dependencies (the secrets are not passed through otherwise). `php-version` defaults to `8.4` (the project minimum) and can be overridden to test against newer PHP versions; the same input is also available on the `i18n` action.
 
 ```yml
 - name: Setup
   uses: WordPress/wporg-repo-tools/.github/actions/setup
   with:
     token: ${{ secrets.GITHUB_TOKEN }}
+    php-version: "8.4"
 ```

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -16,6 +16,11 @@ inputs:
     type: string
     required: false
     default: "false"
+  php-version:
+    description: "PHP version to install on the runner."
+    type: string
+    required: false
+    default: "8.4"
 
 
 runs:
@@ -35,7 +40,7 @@ runs:
     - name: Setup PHP with PECL extension
       uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2.37.0
       with:
-        php-version: "8.4"
+        php-version: ${{ inputs.php-version }}
       env:
         COMPOSER_TOKEN: ${{ inputs.token }}
 

--- a/.github/workflows/validate-actions.yml
+++ b/.github/workflows/validate-actions.yml
@@ -5,6 +5,11 @@ name: Validate composite actions
 # the workflow's working directory so each composite action sees what a real
 # consumer repo looks like (composer.json, package.json, .nvmrc, lockfiles,
 # .wp-env.json, plugin bootstrap, tests/).
+#
+# Each PHP-touching job runs on a matrix of PHP versions so we exercise the
+# minimum supported version (8.4) and the next major (8.5). For test-php we
+# also rewrite the fixture's .wp-env.json#phpVersion so wp-env's cli container
+# (where PHPUnit actually runs) uses the matrix PHP version too.
 
 on:
   pull_request:
@@ -22,7 +27,7 @@ permissions:
 
 jobs:
   setup:
-    name: setup (${{ matrix.packageManager }})
+    name: setup (${{ matrix.packageManager }}, php ${{ matrix.php-version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -30,6 +35,9 @@ jobs:
         packageManager:
           - yarn
           - npm
+        php-version:
+          - "8.4"
+          - "8.5"
     steps:
       - name: Check out this repo as the action source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -46,10 +54,17 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           packageManager: ${{ matrix.packageManager }}
           skip-build: "true"
+          php-version: ${{ matrix.php-version }}
 
   lint:
-    name: lint
+    name: lint (php ${{ matrix.php-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version:
+          - "8.4"
+          - "8.5"
     steps:
       - name: Check out this repo as the action source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -65,13 +80,20 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           packageManager: yarn
+          php-version: ${{ matrix.php-version }}
 
       - name: Run lint action
         uses: ./action-source/.github/actions/lint
 
   i18n:
-    name: i18n
+    name: i18n (php ${{ matrix.php-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version:
+          - "8.4"
+          - "8.5"
     steps:
       - name: Check out this repo as the action source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -98,10 +120,17 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: "--no_taxonomies --no_post_types"
+          php-version: ${{ matrix.php-version }}
 
   test-php:
-    name: test-php
+    name: test-php (php ${{ matrix.php-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version:
+          - "8.4"
+          - "8.5"
     steps:
       - name: Check out this repo as the action source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -112,12 +141,23 @@ jobs:
         shell: bash
         run: cp -a action-source/.github/tests/fixture-consumer/. .
 
+      # PHPUnit runs inside wp-env's cli container, so the wp-env phpVersion
+      # determines what PHP the tests actually execute under. Rewrite the
+      # fixture's .wp-env.json to match the matrix entry.
+      - name: Pin wp-env phpVersion to the matrix value
+        shell: bash
+        run: |
+          jq --arg v "${{ matrix.php-version }}" '.phpVersion = $v' .wp-env.json > .wp-env.json.tmp
+          mv .wp-env.json.tmp .wp-env.json
+          cat .wp-env.json
+
       - name: Run setup action (yarn)
         uses: ./action-source/.github/actions/setup
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           packageManager: yarn
           skip-build: "true"
+          php-version: ${{ matrix.php-version }}
 
       - name: Run test-php action
         uses: ./action-source/.github/actions/test-php

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,9 @@
 	"support": {
 		"issues": "https://github.com/WordPress/wporg-repo-tools/issues"
 	},
+	"require": {
+		"php": "^8.4"
+	},
 	"bin": [
 		"bin/update-configs"
 	]

--- a/templates/composer.json.template
+++ b/templates/composer.json.template
@@ -13,7 +13,9 @@
 			"dealerdirect/phpcodesniffer-composer-installer": true
 		}
 	},
-	"require": {},
+	"require": {
+		"php": "^8.4"
+	},
 	"require-dev" : {
 		"dealerdirect/phpcodesniffer-composer-installer": "^1.0",
 		"wp-coding-standards/wpcs": "^3.0",


### PR DESCRIPTION
## Summary

- Make PHP 8.4 the enforced minimum for this package and for new consumers generated from the template: adds `"php": "^8.4"` to `composer.json` and to `templates/composer.json.template` (the template already pinned `config.platform.php = 8.4`, but only for composer's resolver — `require` is what consumers actually hit).
- Add a `php-version` input (default `"8.4"`) to the `setup` and `i18n` composite actions, passed through to `shivammathur/setup-php`.
- Expand `.github/workflows/validate-actions.yml` so every PHP-touching job (setup, lint, i18n, test-php) runs on a `[8.4, 8.5]` matrix.
- For `test-php` specifically, PHPUnit runs inside wp-env's `cli` container, so the host PHP from setup-php is not what tests actually execute under. The matrix value is also written into the fixture's `.wp-env.json#phpVersion` via `jq` before setup runs, so the container PHP matches the matrix entry.
- README touch-up for the new input.

## Test plan

- [ ] CI `setup` job passes on both PHP 8.4 and PHP 8.5, for both yarn and npm package managers.
- [ ] CI `lint` job passes on both PHP 8.4 and PHP 8.5.
- [ ] CI `i18n` job passes on both PHP 8.4 and PHP 8.5.
- [ ] CI `test-php` job passes on both PHP 8.4 and PHP 8.5 — confirm the "Pin wp-env phpVersion to the matrix value" step output shows `phpVersion: "8.5"` for the 8.5 leg.
- [ ] If `@wordpress/env ^11.0.0` does not yet accept `phpVersion: "8.5"`, the 8.5 `test-php` leg will fail at `wp-env start`; bump `@wordpress/env` in `.github/tests/fixture-consumer/package.json` in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)